### PR TITLE
make relocateFood choose a random location inside the game board

### DIFF
--- a/Snake.cpp
+++ b/Snake.cpp
@@ -169,13 +169,17 @@ bool Snake::wasGameReset()
 {
 	if(_wasReset)
 	{
-		_wasReset=false;
 		return true;
 	}
 	else
 	{
 		return false;
 	}
+}
+
+void Snake::unsetGameReset() 
+{
+	_wasReset=false;
 }
 
 void Snake::checkFood()

--- a/Snake.cpp
+++ b/Snake.cpp
@@ -197,8 +197,8 @@ void Snake::relocateFood()
 {
 	do
 	{
-		food[0].posX = random(0, 14);
-		food[0].posY = random(0, 8);
+		food[0].posX = random(0, _fieldSizeX);
+		food[0].posY = random(0, _fieldSizeY);
 	}while(isPointOnSnake(food[0]));
 }
 

--- a/Snake.h
+++ b/Snake.h
@@ -1,6 +1,6 @@
 /*
 	Yet Another Snake Game Library.
-	Copyright (C) 2014  Emanuel Knöpfel
+	Copyright (C) 2014  Emanuel Knï¿½pfel
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -79,7 +79,8 @@ public:
 	void tick();
 
 	void resetGame();
-	bool wasGameReset();	
+	bool wasGameReset();
+	void unsetGameReset();	
 	int getSnakeLenght();
 	void increaseSize();
 	void setDelay(int moveDelay);

--- a/example/snakysnake/snakysnake.ino
+++ b/example/snakysnake/snakysnake.ino
@@ -76,31 +76,34 @@ void clearScreen()
 	fill_solid(leds, NUM_LEDS, CRGB::Black);
 }
 
+byte resetCounter = 0;
+
 void loop() 
 {	
-	Snake::pixel* snakeLimbs=snakeGame.getSnakeLimbs();//this needs to be updated every frame
-	Snake::pixel* snakeFood = snakeGame.getFoodPositions();//this needs to be updated every frame
-	clearScreen();
-	setPixel(snakeFood[0].posX,8-snakeFood[0].posY,snakeFood[0].pixelColor.r,snakeFood[0].pixelColor.g,snakeFood[0].pixelColor.b); // display the food
-	for(int i=0; i<snakeGame.getSnakeLenght(); i++)
-	{
-		//display the snake, my setpixel method has x=0, y=0 at the top left, but the library has it at bottom left, so I invert the Y-Axis:
-		setPixel(snakeLimbs[i].posX,8-snakeLimbs[i].posY,snakeLimbs[i].pixelColor.r,snakeLimbs[i].pixelColor.g,snakeLimbs[i].pixelColor.b);
-	}
-	FastLED.show();
-	snakeGame.tick();//main loop for the snake library
-	if(snakeGame.wasGameReset())// if the snake bit itself or the wall, flash a little
-	{
-		for(int i=0; i<30; i++)
-		{
-			changeRGBtoGBR();
+	EVERY_N_MILLISECONDS( 30 ) {
+		if(snakeGame.wasGameReset()) // if the snake bit itself or the wall, flash a little
+        {
+            changeRGBtoGBR();
+            FastLED.show();
+            resetCounter++;
+            if (resetCounter > 30) {
+                resetCounter = 0;
+                snakeGame.unsetGameReset();
+            }
+        } else {
+			Snake::pixel* snakeLimbs=snakeGame.getSnakeLimbs();//this needs to be updated every frame
+			Snake::pixel* snakeFood = snakeGame.getFoodPositions();//this needs to be updated every frame
+			clearScreen();
+			setPixel(snakeFood[0].posX,8-snakeFood[0].posY,snakeFood[0].pixelColor.r,snakeFood[0].pixelColor.g,snakeFood[0].pixelColor.b); // display the food
+			for(int i=0; i<snakeGame.getSnakeLenght(); i++)
+			{
+				//display the snake, my setpixel method has x=0, y=0 at the top left, but the library has it at bottom left, so I invert the Y-Axis:
+				setPixel(snakeLimbs[i].posX,8-snakeLimbs[i].posY,snakeLimbs[i].pixelColor.r,snakeLimbs[i].pixelColor.g,snakeLimbs[i].pixelColor.b);
+			}
 			FastLED.show();
-			delay(40);
+			snakeGame.tick();//main loop for the snake library
 		}
 	}
-	else
-		delay(30);
-
 }
 
 byte incomingByte=0;

--- a/example/snakysnake/snakysnake.ino
+++ b/example/snakysnake/snakysnake.ino
@@ -73,10 +73,7 @@ void changeRGBtoGBR()
 
 void clearScreen()
 {
-		for(int whiteLed = 0; whiteLed < NUM_LEDS; whiteLed++)
-		{
-			leds[whiteLed].setRGB( 3, 3, 3);
-		}
+	fill_solid(leds, NUM_LEDS, CRGB::Black);
 }
 
 void loop() 


### PR DESCRIPTION
relocateFood was hardcoded to use 8,14 as it's random location bounds, which will either cause the food to spawn only in that one section of the display, or appear outside the display if it is smaller than 8,14